### PR TITLE
Fix flickering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ It sports high configurability through a (soon to be) extensive Lua API, with pl
 > <summary>Click me</summary>
 >
 > All videos were recorded using [Screenkey](https://gitlab.com/screenkey/screenkey) and the Winit backend.
-> Expect minor flickering here and there, but I hope to fix that in the future.
 > 
 > https://github.com/Ottatop/pinnacle/assets/120758733/5b6b224b-3031-4a1c-9375-1143f1bfc0e3
 >

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -232,6 +232,16 @@ pub fn run_winit() -> anyhow::Result<()> {
 
                 pointer_element.set_status(state.cursor_status.clone());
 
+                if state.pause_rendering {
+                    state.space.refresh();
+                    state.popup_manager.cleanup();
+                    display
+                        .flush_clients()
+                        .expect("failed to flush client buffers");
+
+                    return TimeoutAction::ToDuration(Duration::from_millis(1));
+                }
+
                 let Backend::Winit(backend) = &mut state.backend else { unreachable!() };
                 let full_redraw = &mut backend.full_redraw;
                 *full_redraw = full_redraw.saturating_sub(1);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -95,7 +95,7 @@ impl CompositorHandler for State {
     }
 
     fn commit(&mut self, surface: &WlSurface) {
-        // tracing::debug!("commit");
+        // tracing::debug!("commit on surface {:?}", surface);
 
         X11Wm::commit_hook::<CalloopData>(surface);
 

--- a/src/window/window_state.rs
+++ b/src/window/window_state.rs
@@ -114,6 +114,24 @@ pub enum LocationRequestState {
     Acknowledged(Point<i32, Logical>),
 }
 
+impl LocationRequestState {
+    /// Returns `true` if the location request state is [`Idle`].
+    ///
+    /// [`Idle`]: LocationRequestState::Idle
+    #[must_use]
+    pub fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
+    /// Returns `true` if the location request state is [`Acknowledged`].
+    ///
+    /// [`Acknowledged`]: LocationRequestState::Acknowledged
+    #[must_use]
+    pub fn is_acknowledged(&self) -> bool {
+        matches!(self, Self::Acknowledged(..))
+    }
+}
+
 impl WindowElement {
     /// This method uses a [`RefCell`].
     pub fn toggle_floating(&self) {


### PR DESCRIPTION
This PR fixes #29 and other flickering by pausing rendering until all windows have committed pending changes. This *will* introduce some latency when windows resize, but the fix to flickering should more than makeup for that.